### PR TITLE
Added import of spt.h to spt_debug.c

### DIFF
--- a/src/spt_debug.c
+++ b/src/spt_debug.c
@@ -15,6 +15,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#include "spt.h"
+
 void spt_debug(const char *fmt, ...)
 {
     static int enabled = -1;


### PR DESCRIPTION
This is necessary to enforce the declaration of spt_debug with the HIDDEN attribute. Without this, linking fails on some CentOS and RHEL builds with misleading errors about requiring -fPIC flags.
