### PR TITLE
Add compatibility with Python 2.4

### DIFF
--- a/src/spt_python.h
+++ b/src/spt_python.h
@@ -56,7 +56,7 @@ void Py_GetArgcArgv(int *argc, argv_t ***argv);
 
 /* Adds missing type in Py2.4 */
 #if PY_MAJOR_VERSION == 2 && PY_MINOR_VERSION == 4
-typedef int Py_ssize_t;
+typedef ssize_t Py_ssize_t;
 #endif
 
 #endif  /* IS_PY3K > 2 */


### PR DESCRIPTION
Python 2.4's include files do not expose the 'Py_ssize_t' type, causing the build process for py-setproctitle to fail.

This pull request contains code to expose the type if building for Python 2.4, based on the definition of the 'Py_ssize_t' type found in Python 3.3's 'include\pyport.h' file.

With this change, py-setproctitle builds, installs, and runs successfully under Python 2.4.
