### PR TITLE
Fix build on Windows with MS compiler

### DIFF
--- a/src/c.h
+++ b/src/c.h
@@ -32,7 +32,7 @@ typedef char bool;
 /* Let's use our version of strlcpy to avoid portability problems */
 size_t spt_strlcpy(char *dst, const char *src, size_t siz);
 
-#ifdef WIN32
+#ifdef _WIN32
 #include <Windows.h>
 #endif
 

--- a/src/spt_setup.c
+++ b/src/spt_setup.c
@@ -21,7 +21,7 @@
 extern char **environ;
 #endif
 
-#ifndef WIN32
+#ifndef _WIN32
 
 /* Return a concatenated version of a strings vector.
  *
@@ -424,7 +424,7 @@ exit:
     return rv;
 }
 
-#endif  /* !WIN32 */
+#endif  /* !_WIN32 */
 
 
 /* Initialize the module internal functions.
@@ -444,7 +444,7 @@ spt_setup(void)
 {
     int rv = -1;
 
-#ifndef WIN32
+#ifndef _WIN32
     int argc = 0;
     char **argv = NULL;
     char *init_title;

--- a/src/spt_status.c
+++ b/src/spt_status.c
@@ -40,7 +40,9 @@
 
 #include "spt_config.h"
 
+#ifndef _WIN32
 #include <unistd.h>
+#endif
 #ifdef HAVE_SYS_PSTAT_H
 #include <sys/pstat.h>          /* for HP-UX */
 #endif
@@ -108,7 +110,7 @@ bool        update_process_title = true;
 #define PS_USE_CHANGE_ARGV
 #elif defined(__linux__) || defined(_AIX) || defined(__sgi) || (defined(sun) && !defined(BSD)) || defined(ultrix) || defined(__ksr__) || defined(__osf__) || defined(__svr4__) || defined(__svr5__) || defined(__darwin__)
 #define PS_USE_CLOBBER_ARGV
-#elif defined(WIN32)
+#elif defined(_WIN32)
 #define PS_USE_WIN32
 #else
 #define PS_USE_NONE


### PR DESCRIPTION
The microsoft compiler doesn't define WIN32, only _WIN32. Also unistd.h does not exist on windows. I think mingw defines _WIN32 and WIN32, so this shouldn't break anything.