### PR TITLE
Allow pyrun to be built with Python 3.8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,12 +10,17 @@ PYTHON ?= python
 PYCONFIG ?= python-config
 PY2TO3 ?= 2to3
 
-# PYVER value is 2 or 3
-PYVER := $(shell $(PYTHON) -c "import sys; print(sys.version_info[0])")
+# PYVER value is 2 for Python 2, 3 for Python 3 < 3.8, 3embed for Python >= 3.8
+PYVER := $(shell $(PYTHON) -c "import sys; print('%d%s' % (sys.version_info[0], 'embed' if sys.version_info >= (3, 8) else ''))")
 ROOT_PATH := $(shell pwd)
 
 PYINC := $(shell $(PYCONFIG) --includes)
-PYLIB := $(shell $(PYCONFIG) --ldflags) -L$(shell $(PYCONFIG) --prefix)/lib
+
+ifeq (3embed,$(PYVER))
+   PYLIB := $(shell $(PYCONFIG) --ldflags --embed)
+else
+   PYLIB := $(shell $(PYCONFIG) --ldflags) -L$(shell $(PYCONFIG) --prefix)/lib
+endif
 
 BUILD_DIR = build/lib.$(PYVER)
 

--- a/Makefile
+++ b/Makefile
@@ -49,8 +49,8 @@ py3:
 	$(MKDIR) py3/src
 	$(MKDIR) py3/tests
 	for f in *.rst setup.py COPYRIGHT MANIFEST.in src/*.c src/*.h tests/*.py tests/*.c; do cp -v $$f py3/$$f; done
-	# setup.py should be executable with python3 as distribute
-	# currenlty doesn't seem to try to convert it
+	# setup.py should be executable with python3 as distributed
+	# currently doesn't seem to be, so try to convert it
 	$(PY2TO3) -w --no-diffs py3/tests
 
 tests/pyrun3: tests/pyrun.c


### PR DESCRIPTION
To link to libpython with Python 3.8 --embed is needed with
python-config:
https://docs.python.org/3/whatsnew/3.8.html#debug-build-uses-the-same-abi-as-release-build

---

.SHELLSTATUS is 3.5 years old, since GNU make 4.2.
http://git.savannah.gnu.org/cgit/make.git/tree/NEWS?id=33bda4008650c48816331c04022176f48c213fb3#n114


Also some typo fixes.