### PR TITLE
Correct conditional platform support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ elif sys.platform == 'darwin':
     define_macros['__darwin__'] = 1
 
 elif 'bsd' in sys.platform:     # OMG, how many of them are?
+    define_macros['BSD'] = 1
     define_macros['HAVE_SETPROCTITLE'] = 1
     define_macros['HAVE_PS_STRING'] = 1
 

--- a/setup.py
+++ b/setup.py
@@ -5,8 +5,6 @@ setproctitle setup script.
 Copyright (c) 2009-2016 Daniele Varrazzo <daniele.varrazzo@gmail.com>
 """
 
-import os
-import re
 import sys
 
 try:
@@ -23,15 +21,7 @@ define_macros = {}
 define_macros['SPT_VERSION'] = VERSION
 
 if sys.platform.startswith('linux'):
-    try:
-        linux_version = list(map(int,
-            re.search("[.0-9]+", os.popen("uname -r").read())
-            .group().split(".")[:3]))
-    except:
-        pass
-    else:
-        if linux_version >= [2, 6, 9]:
-            define_macros['HAVE_SYS_PRCTL_H'] = 1
+    define_macros['HAVE_SYS_PRCTL_H'] = 1
 
 elif sys.platform == 'darwin':
     # __darwin__ symbol is not defined; __APPLE__ is instead.

--- a/setup.py
+++ b/setup.py
@@ -38,13 +38,8 @@ elif sys.platform == 'darwin':
     define_macros['__darwin__'] = 1
 
 elif 'bsd' in sys.platform:     # OMG, how many of them are?
-    # Old BSD versions don't have setproctitle
-    # TODO: not tested on an "old BSD"
-    if 0 == os.spawnlp(os.P_WAIT, 'grep',
-            'grep', '-q', 'setproctitle', '/usr/include/unistd.h', '/usr/include/stdlib.h'):
-        define_macros['HAVE_SETPROCTITLE'] = 1
-    else:
-        define_macros['HAVE_PS_STRING'] = 1
+    define_macros['HAVE_SETPROCTITLE'] = 1
+    define_macros['HAVE_PS_STRING'] = 1
 
 # NOTE: the module may work on HP-UX using pstat
 # thus setting define_macros['HAVE_SYS_PSTAT_H']


### PR DESCRIPTION
This change simplifies the conditionals in `setup.py` by removing outdated/unsupported version checks for \*BSD and Linux and also adds a pedantic definition when dealing with \*BSD, as there are conditionals in `src/spt_status.c` that look for the definition.