### PR TITLE
Require string.h with strdup(3)

### DIFF
--- a/src/spt_setup.c
+++ b/src/spt_setup.c
@@ -13,6 +13,8 @@
 #include "spt.h"
 #include "spt_status.h"
 
+#include <string.h>
+
 /* Darwin doesn't export environ */
 #if defined(__darwin__)
 #include <crt_externs.h>


### PR DESCRIPTION
This change adds string.h as an include to src/spt_setup.c so
the sources compile without warnings.

This issue was noticed in #62.

Signed-off-by: Enji Cooper <yaneurabeya@gmail.com>