### PR TITLE
define PY_SSIZE_T_CLEAN to avoid deprecation warning

### DIFF
--- a/src/spt_python.h
+++ b/src/spt_python.h
@@ -11,6 +11,10 @@
 #ifndef SPT_PYTHON_H
 #define SPT_PYTHON_H
 
+#if PY_MAJOR_VERSION >= 3
+#define PY_SSIZE_T_CLEAN
+#endif
+
 #include <Python.h>
 
 /* Things change a lot here... */


### PR DESCRIPTION
Fix deprecation python warning when using getproctitle() due to 
missing #define of PY_SSIZE_T_CLEAN prior to include of Python.h.

* https://docs.python.org/3/c-api/intro.html

This change addresses the need by:

* Deprecation error from setproctitle.getproctitle()