### PR TITLE
Remove useless guard around PY_SSIZE_T_CLEAN

### DIFF
--- a/src/spt_python.h
+++ b/src/spt_python.h
@@ -11,9 +11,7 @@
 #ifndef SPT_PYTHON_H
 #define SPT_PYTHON_H
 
-#if PY_MAJOR_VERSION >= 3
 #define PY_SSIZE_T_CLEAN
-#endif
 
 #include <Python.h>
 


### PR DESCRIPTION
I believe commit e1aac2a404e1990f0fb4d4abb83e357818893d82 is not correct as `PY_SSIZE_T_CLEAN` should be defined _before_ including `Python.h` instead of afterwards because it relies on `PY_MAJOR_VERSION` but that's not defined yet.

This can be verified by putting an `#error foo` in the code and see that it won't be triggered with the original commit.