### PR TITLE
Fix skipping embedded tests with pypy

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "pypy3"]
     steps:
       - name: Checkout repos
         uses: actions/checkout@v2

--- a/tests/setproctitle_test.py
+++ b/tests/setproctitle_test.py
@@ -340,12 +340,10 @@ print(os.popen("ps -x -o pid,command 2> /dev/null").read())
 
 
 @pytest.mark.embedded
+@pytest.mark.skipif(IS_PYPY, reason="skip test, pypy")
 def test_embedded(pyrun, spt_directory):
     """Check the module works with embedded Python.
     """
-    if IS_PYPY:
-        pytest.skip("skip test, pypy")
-
     if not os.path.exists("/proc/%s/cmdline" % os.getpid()):
         pytest.skip("known failure: '/proc/PID/cmdline' not available")
 
@@ -371,11 +369,9 @@ print(os.popen("ps -x -o pid,command 2> /dev/null").read())
 
 
 @pytest.mark.embedded
+@pytest.mark.skipif(IS_PYPY, reason="skip test, pypy")
 def test_embedded_many_args(pyrun, spt_directory):
     """Check more complex cmdlines are handled in embedded env too."""
-    if IS_PYPY:
-        pytest.skip("skip test, pypy")
-
     if not os.path.exists("/proc/%s/cmdline" % os.getpid()):
         pytest.skip("known failure: '/proc/PID/cmdline' not available")
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{36,37,38,39}
+envlist = py{36,37,38,39},pypy3
 
 [testenv]
 commands =


### PR DESCRIPTION
Fix skipping embedded tests by using the 'skipif' decorator.  The tests
need to be skipped early, as otherwise they error out trying to
initialize pyconfig fixture.