### PR TITLE
Fix Windows build

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -2,7 +2,7 @@ name: Build packages
 on: [workflow_dispatch]
 jobs:
   build-manylinux:
-    name: Build packages
+    name: Build Linux packages
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout repos
@@ -24,7 +24,39 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v2
         with:
-          name: packages
+          name: linux_packages
           path: |
             dist/*.tar.gz
             dist/*-manylinux1_*.whl
+
+  build-windows:
+    name: Build Windows packages
+    runs-on: windows-latest
+    strategy:
+      max-parallel: 100
+      matrix:
+        python-version: [3.6, 3.7, 3.8, 3.9]
+        architecutre: ['x64', 'x86']
+
+    steps:
+    - name: Checkout repos
+      uses: actions/checkout@v1
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install Python dependencies
+      shell: cmd
+      run: pip install wheel
+
+    - name: Build x86_64 packages
+      shell: cmd
+      run: python setup.py bdist_wheel
+
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v1
+      with:
+          name: windows_packages
+          path: dist

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,3 +23,26 @@ jobs:
 
       - name: Run tests
         run: tox -e ${{matrix.python-version}} -- -vrsx --color=yes
+
+  build-windows:
+    name: Test Windows build
+    runs-on: windows-latest
+    strategy:
+      max-parallel: 100
+      matrix:
+        python-version: [3.6, 3.7, 3.8, 3.9]
+
+    steps:
+    - name: Checkout repos
+      uses: actions/checkout@v1
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install Tox
+      run: pip install tox
+
+    - name: Run tests
+      run: tox -e ${{matrix.python-version}} -- -vrsx --color=yes

--- a/src/spt_setup.c
+++ b/src/spt_setup.c
@@ -19,7 +19,7 @@
 #if defined(__darwin__)
 #include <crt_externs.h>
 #define environ (*_NSGetEnviron())
-#else
+#elif !defined(_WIN32)
 extern char **environ;
 #endif
 

--- a/src/spt_setup.c
+++ b/src/spt_setup.c
@@ -456,7 +456,7 @@ int
 spt_setup(void)
 {
     const int not_happened = 3;
-    static int rv = not_happened;
+    static int rv = 3;
 
     /* Make sure setup happens just once, either successful or failed */
     if (rv != not_happened) {

--- a/tests/setproctitle_test.py
+++ b/tests/setproctitle_test.py
@@ -18,8 +18,11 @@ import pytest
 
 from .conftest import run_script
 
-
 IS_PYPY = "__pypy__" in sys.builtin_module_names
+
+if sys.platform == 'win32':
+    pytest.skip("skipping Posix tests on Windows",
+                allow_module_level=True)
 
 
 def test_runner():

--- a/tests/setthreadtitle_test.py
+++ b/tests/setthreadtitle_test.py
@@ -1,7 +1,12 @@
 import os
 import pytest
+import sys
 
 from .conftest import run_script
+
+if sys.platform == 'win32':
+    pytest.skip("skipping Posix tests on Windows",
+                allow_module_level=True)
 
 
 def test_thread_title_unchanged():

--- a/tests/test_win32.py
+++ b/tests/test_win32.py
@@ -1,0 +1,19 @@
+import pytest
+import setproctitle
+import sys
+
+if sys.platform != 'win32':
+    pytest.skip("skipping Windows tests",
+                allow_module_level=True)
+
+
+def test_setproctitle():
+    title = "setproctitle_test"
+    setproctitle.setproctitle(title)
+    assert title == setproctitle.getproctitle()
+
+def test_setthreadtitle():
+    title = "setproctitle_test"
+    # This is currently a no-op on Windows. Let's make sure
+    # that at least it doesn't error out.
+    setproctitle.setthreadtitle(title)


### PR DESCRIPTION
Fix Windows build

At the moment, py-setproctitle cannot be compiled using Visual
Studio, which complains about a certain static variable initialization.

This PR updates this initialization, allowing the project
to be compiled successfully: http://paste.openstack.org/raw/800734/

At the same time, we're providing GitHub actions that will take care
of building Windows Python wheels.

Closes: #89
Related issue: #47 

Signed-off-by: Lucian Petrut <lpetrut@cloudbasesolutions.com>