### PR TITLE
Build binary wheels on MacOS

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -115,3 +115,34 @@ jobs:
         with:
           name: packages_windows
           path: dist
+
+
+  build-macos-x64:
+    name: Build MacOS packages
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        python-version: [3.6, 3.7, 3.8, 3.9]
+
+    steps:
+      - name: Checkout repos
+        uses: actions/checkout@v2
+
+      - name: Set up Python ${{matrix.python-version}}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{matrix.python-version}}
+
+      - name: Install Python dependencies
+        shell: bash
+        run: pip install wheel
+
+      - name: Build macos-x64 packages
+        shell: bash
+        run: python setup.py bdist_wheel
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: packages_macos
+          path: dist


### PR DESCRIPTION
I've added the ability to build binary wheels for the Mac.

I was also going to add them to tests but the tests are failing for MacOS.

See for example - https://github.com/Chia-Network/py-setproctitle/runs/1794589488?check_suite_focus=true#step:5:34

Happy to open a next PR with the tests if that would be helpful. You can see that we took a stab at fixing a MacOS issue earlier - https://github.com/dvarrazzo/py-setproctitle/commit/fb4641d80c8d4fa5a2f4d6cb3e66a0b394cb6225

I've verified that the built wheels work on MacOS python 3.7.7 and 3.8.5