### PR TITLE
Add Python 3.10 tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10.0-rc.3", "pypy3"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10.0-rc.2", "pypy3"]
 
     steps:
       - name: Checkout repos

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "pypy3"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10.0-beta - 3.10", "pypy3"]
 
     steps:
       - name: Checkout repos
@@ -18,27 +18,19 @@ jobs:
         with:
           python-version: ${{matrix.python-version}}
           architecture: x64
-        if: ${{ matrix.python-version != '3.10'}}
-
-      - name: Set up Python 3.10
-        uses: actions/setup-python@v2
-        with:
-          python-version: "3.10.0-alpha - 3.10.0"
-          architecture: x64
-        if: ${{ matrix.python-version == '3.10'}}
 
       - name: Install Tox
         run: pip install tox
 
       - name: Run tests
-        run: tox -e ${{ matrix.python-version }} -- -vrsx --color=yes
+        run: tox -- -vrsx --color=yes
 
   windows-tests:
     name: Python ${{matrix.python-version}} tests on Windows ${{matrix.architecture}}
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
+        python-version: [3.6, 3.7, 3.8, 3.9, "3.10.0-beta - 3.10"]
         architecture: ["x64", "x86"]
 
     steps:
@@ -50,17 +42,9 @@ jobs:
         with:
           python-version: ${{matrix.python-version}}
           architecture: ${{matrix.architecture}}
-        if: ${{ matrix.python-version != '3.10'}}
-
-      - name: Set up Python ${{matrix.python-version}}
-        uses: actions/setup-python@v2
-        with:
-          python-version: "3.10.0-alpha - 3.10.0"
-          architecture: ${{matrix.architecture}}
-        if: ${{ matrix.python-version == '3.10'}}
 
       - name: Install Tox
         run: pip install tox
 
       - name: Run tests
-        run: tox -e ${{matrix.python-version}} -- -vrsx --color=yes
+        run: tox -- -vrsx --color=yes

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,7 @@ jobs:
           architecture: ${{matrix.architecture}}
 
       - name: Install Tox
-        run: pip install tox
+        run: pip install tox tox-gh-actions
 
       - name: Run tests
         run: tox -- -vrsx --color=yes

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,14 +13,14 @@ jobs:
       - name: Checkout repos
         uses: actions/checkout@v2
 
-      - name: Set up Python
+      - name: Set up Python ${{matrix.python-version}}
         uses: actions/setup-python@v2
         with:
           python-version: ${{matrix.python-version}}
           architecture: x64
         if: ${{ matrix.python-version != '3.10'}}
 
-      - name: Set up Python
+      - name: Set up Python 3.10
         uses: actions/setup-python@v2
         with:
           python-version: "3.10.0-alpha - 3.10.0"
@@ -38,8 +38,8 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
-        architecture: ['x64', 'x86']
+        python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
+        architecture: ["x64", "x86"]
 
     steps:
       - name: Checkout repos
@@ -50,6 +50,14 @@ jobs:
         with:
           python-version: ${{matrix.python-version}}
           architecture: ${{matrix.architecture}}
+        if: ${{ matrix.python-version != '3.10'}}
+
+      - name: Set up Python ${{matrix.python-version}}
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.10.0-alpha - 3.10.0"
+          architecture: ${{matrix.architecture}}
+        if: ${{ matrix.python-version == '3.10'}}
 
       - name: Install Tox
         run: pip install tox

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
           architecture: x64
 
       - name: Install Tox
-        run: pip install tox
+        run: pip install tox tox-gh-actions
 
       - name: Run tests
         run: tox -- -vrsx --color=yes

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "pypy3"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10.0-rc.3", "pypy3"]
 
     steps:
       - name: Checkout repos

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,10 +20,10 @@ jobs:
           architecture: x64
 
       - name: Install Tox
-        run: pip install tox
+        run: pip install tox tox-py
 
       - name: Run tests
-        run: tox -e ${{matrix.python-version}} -- -vrsx --color=yes
+        run: tox --py current -- -vrsx --color=yes
 
   windows-tests:
     name: Python ${{matrix.python-version}} tests on Windows ${{matrix.architecture}}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10-dev", "pypy3"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "pypy3"]
 
     steps:
       - name: Checkout repos
@@ -18,12 +18,20 @@ jobs:
         with:
           python-version: ${{matrix.python-version}}
           architecture: x64
+        if: ${{ matrix.python-version != '3.10'}}
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.10.0-alpha - 3.10.0"
+          architecture: x64
+        if: ${{ matrix.python-version == '3.10'}}
 
       - name: Install Tox
-        run: pip install tox tox-py
+        run: pip install tox
 
       - name: Run tests
-        run: tox --py current -- -vrsx --color=yes
+        run: tox -e ${{ matrix.python-version }} -- -vrsx --color=yes
 
   windows-tests:
     name: Python ${{matrix.python-version}} tests on Windows ${{matrix.architecture}}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 ---
 name: Tests
-on: [push]
+on: [push, pull_request]
 jobs:
   linux-tests:
     name: Python ${{matrix.python-version}} tests on Linux

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10.0-rc.2", "pypy3"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10-dev", "pypy3"]
 
     steps:
       - name: Checkout repos

--- a/setup.py
+++ b/setup.py
@@ -8,9 +8,9 @@ Copyright (c) 2009-2021 Daniele Varrazzo <daniele.varrazzo@gmail.com>
 import sys
 
 try:
-    from setuptools import Extension, setup
+    from setuptools import setup, Extension
 except ImportError:
-    from distutils.core import Extension, setup
+    from distutils.core import setup, Extension
 
 VERSION = "1.2.3.dev0"
 

--- a/setup.py
+++ b/setup.py
@@ -8,9 +8,9 @@ Copyright (c) 2009-2021 Daniele Varrazzo <daniele.varrazzo@gmail.com>
 import sys
 
 try:
-    from setuptools import setup, Extension
+    from setuptools import Extension, setup
 except ImportError:
-    from distutils.core import setup, Extension
+    from distutils.core import Extension, setup
 
 VERSION = "1.2.3.dev0"
 
@@ -95,6 +95,6 @@ setup(
     python_requires=">=3.6",
     classifiers=classifiers,
     ext_modules=[mod_spt],
-    extras_require={"test": ["pytest>=6.1,<6.2"]},
+    extras_require={"test": ["pytest>=6.2,<6.3"]},
     **kwargs
 )

--- a/setup.py
+++ b/setup.py
@@ -95,6 +95,6 @@ setup(
     python_requires=">=3.6",
     classifiers=classifiers,
     ext_modules=[mod_spt],
-    extras_require={"test": ["pytest>=6.2,<6.3"]},
+    extras_require={"test": ["pytest>=6.2.5,<6.3"]},
     **kwargs
 )

--- a/setup.py
+++ b/setup.py
@@ -74,6 +74,7 @@ Programming Language :: Python :: 3.6
 Programming Language :: Python :: 3.7
 Programming Language :: Python :: 3.8
 Programming Language :: Python :: 3.9
+Programming Language :: Python :: 3.10
 Operating System :: POSIX :: Linux
 Operating System :: POSIX :: BSD
 Operating System :: MacOS :: MacOS X

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = 3.6, 3.7, 3.8, 3.9, pypy3
+envlist = 3.6, 3.7, 3.8, 3.9, 3.10, pypy3
 
 [testenv]
 commands =
@@ -18,3 +18,6 @@ basepython = python3.8
 
 [testenv:3.9]
 basepython = python3.9
+
+[testenv:3.10]
+basepython = python3.10

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,13 @@
+[gh-actions]
+python =
+    3.6: py36
+    3.7: py37
+    3.8: py38
+    3.9: py39
+    3.10: py310
+
 [tox]
-envlist = 3.6, 3.7, 3.8, 3.9, 3.10, pypy3
+envlist = py36, py37, py38, py39, py310, pypy3
 
 [testenv]
 commands =
@@ -7,17 +15,17 @@ commands =
 extras =
     test
 
-[testenv:3.6]
+[testenv:py36]
 basepython = python3.6
 
-[testenv:3.7]
+[testenv:py37]
 basepython = python3.7
 
-[testenv:3.8]
+[testenv:py38]
 basepython = python3.8
 
-[testenv:3.9]
+[testenv:py39]
 basepython = python3.9
 
-[testenv:3.10]
+[testenv:py310]
 basepython = python3.10


### PR DESCRIPTION
Add Python 3.10.0-rc.2 to the pipeline.

I've basically copied Adam's code: https://github.com/adamchainz/patchy/blob/main/.github/workflows/main.yml
Using [tox-py](https://pypi.org/project/tox-py/) (which I've just noticed has zero stars) 

It does get the right version as you see here: https://github.com/dvarrazzo/py-setproctitle/pull/102/checks?check_run_id=3769535755

If you prefer the approach you did on psycopg, let me know. I took the opportunity to learn a little bit more about the options, so that's why I didn't directly do what you suggested.