### PR TITLE
Fixed #10: Added support for process name in MacOS Activity Monitor

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,12 @@
 Releases history
 ----------------
 
+Version 1.3.0
+-------------
+
+- Added support for displaying title as the process name in MacOS Activity Monitor (issue #10).
+
+
 Version 1.2.3
 -------------
 

--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@ A Python module to customize the process title
 :author: Daniele Varrazzo
 
 The ``setproctitle`` module allows a process to change its title (as displayed
-by system tools such as ``ps`` and ``top``).
+by system tools such as ``ps``, ``top`` or MacOS Activity Monitor).
 
 Changing the title is mostly useful in multi-process systems, for example
 when a master process is forked: changing the children's title allows to

--- a/setup.py
+++ b/setup.py
@@ -17,12 +17,15 @@ VERSION = "1.2.4.dev0"
 define_macros = {}
 define_macros["SPT_VERSION"] = VERSION
 
+platform_sources = []
+
 if sys.platform.startswith("linux"):
     define_macros["HAVE_SYS_PRCTL_H"] = 1
 
 elif sys.platform == "darwin":
     # __darwin__ symbol is not defined; __APPLE__ is instead.
     define_macros["__darwin__"] = 1
+    platform_sources.append("src/darwin_set_process_name.c")
 
 elif "bsd" in sys.platform:  # OMG, how many of them are?
     define_macros["BSD"] = 1
@@ -43,7 +46,7 @@ mod_spt = Extension(
         "src/spt_setup.c",
         "src/spt_status.c",
         "src/spt_strlcpy.c",
-    ],
+    ] + platform_sources,
 )
 
 # patch distutils if it can't cope with the "classifiers" or

--- a/src/darwin_set_process_name.c
+++ b/src/darwin_set_process_name.c
@@ -1,0 +1,158 @@
+/*
+
+Set process title in a way compatible with Activity Monitor and other
+MacOS system tools.
+
+Idea is borrowed from libuv (used by node.js)
+See https://github.com/libuv/libuv/blob/v1.x/src/unix/darwin-proctitle.c
+Implementation rewritten from scratch, fixing various libuv bugs among other things
+
+*/
+
+#include <CoreFoundation/CoreFoundation.h>
+
+#include <dlfcn.h>
+#include <pthread.h>
+
+#include "darwin_set_process_name.h"
+
+#define DONE_IF(cond) if (cond) goto done;
+
+/* Undocumented Launch Services functions */
+CFTypeRef LSGetCurrentApplicationASN(void);
+OSStatus LSSetApplicationInformationItem(int, CFTypeRef, CFStringRef, CFStringRef, CFDictionaryRef*);
+CFDictionaryRef LSApplicationCheckIn(int, CFDictionaryRef);
+void LSSetApplicationLaunchServicesServerConnectionStatus(uint64_t, void *);
+
+typedef struct {
+    void * application_services_handle;
+
+    CFBundleRef launch_services_bundle;
+    typeof(LSGetCurrentApplicationASN) * pLSGetCurrentApplicationASN;
+    typeof(LSSetApplicationInformationItem) * pLSSetApplicationInformationItem;
+    typeof(LSApplicationCheckIn) * pLSApplicationCheckIn;
+    typeof(LSSetApplicationLaunchServicesServerConnectionStatus) * pLSSetApplicationLaunchServicesServerConnectionStatus;
+
+    CFStringRef * display_name_key_ptr;
+
+} launch_services_t;
+
+static bool launch_services_init(launch_services_t * it) {
+    enum {
+        has_nothing,
+        has_application_services_handle
+    } state = has_nothing;
+    bool ret = false;
+
+    it->application_services_handle = dlopen("/System/Library/Frameworks/"
+                                             "ApplicationServices.framework/"
+                                             "Versions/Current/ApplicationServices",
+                                             RTLD_LAZY | RTLD_LOCAL);
+    DONE_IF(!it->application_services_handle);
+    ++state;
+    
+    it->launch_services_bundle = CFBundleGetBundleWithIdentifier(CFSTR("com.apple.LaunchServices"));
+    DONE_IF(!it->launch_services_bundle);
+
+#define LOAD_METHOD(name) \
+    *(void **)(&it->p ## name ) = \
+        CFBundleGetFunctionPointerForName(it->launch_services_bundle, CFSTR("_" #name)); \
+    DONE_IF(!it->p ## name);
+
+    LOAD_METHOD(LSGetCurrentApplicationASN)
+    LOAD_METHOD(LSSetApplicationInformationItem)
+    LOAD_METHOD(LSApplicationCheckIn)
+    LOAD_METHOD(LSSetApplicationLaunchServicesServerConnectionStatus)
+
+#undef LOAD_METHOD
+
+    it->display_name_key_ptr = 
+        CFBundleGetDataPointerForName(it->launch_services_bundle, CFSTR("_kLSDisplayNameKey"));
+    DONE_IF(!it->display_name_key_ptr || !*it->display_name_key_ptr);
+
+    ret = true;
+
+done:
+    switch(state) {
+        case has_application_services_handle: if (!ret) dlclose(it->application_services_handle);
+        case has_nothing: ;
+    }
+    return ret;
+}
+
+static inline void launch_services_destroy(launch_services_t * it) {
+    dlclose(it->application_services_handle);
+}
+
+static bool launch_services_set_process_title(const launch_services_t * it, const char * title) {
+
+    enum {
+        has_nothing,
+        has_cf_title
+    } state = has_nothing;
+    bool ret = false;
+
+    CFTypeRef asn;
+    CFStringRef cf_title;
+    
+    it->pLSSetApplicationLaunchServicesServerConnectionStatus(0, NULL);
+    it->pLSApplicationCheckIn(-2, CFBundleGetInfoDictionary(CFBundleGetMainBundle()));
+
+    asn = it->pLSGetCurrentApplicationASN();
+    DONE_IF(!asn);
+    
+    cf_title = CFStringCreateWithCString(NULL, title, kCFStringEncodingUTF8);
+    DONE_IF(!cf_title);
+    ++state;
+    DONE_IF(it->pLSSetApplicationInformationItem(-2,  /* Magic value: presumably "LS_SET_PROCESS_TITLE" constant */
+                                                 asn,
+                                                 *it->display_name_key_ptr,
+                                                 cf_title,
+                                                 NULL) != noErr);
+    ret = true;
+done:
+    switch(state) {
+        case has_cf_title: CFRelease(cf_title);
+        case has_nothing:  ;
+    }
+
+    return ret;
+}
+
+static bool darwin_pthread_setname_np(const char* name) {
+    char namebuf[64];  /* MAXTHREADNAMESIZE according to libuv */
+  
+    strncpy(namebuf, name, sizeof(namebuf) - 1);
+    namebuf[sizeof(namebuf) - 1] = '\0';
+
+    return (pthread_setname_np(namebuf) != 0);
+}
+
+
+bool darwin_set_process_title(const char * title) {
+
+    enum {
+        has_nothing,
+        has_launch_services
+    } state = has_nothing;
+    bool ret = false;
+
+    launch_services_t launch_services;
+    
+    DONE_IF(!launch_services_init(&launch_services));
+    ++state;
+
+    DONE_IF(!launch_services_set_process_title(&launch_services, title));
+
+    (void)darwin_pthread_setname_np(title); 
+
+    ret = true;
+
+done:
+    switch(state) {
+        case has_launch_services: launch_services_destroy(&launch_services);
+        case has_nothing: ;
+    }
+
+    return ret;
+}

--- a/src/darwin_set_process_name.h
+++ b/src/darwin_set_process_name.h
@@ -1,0 +1,8 @@
+#ifndef HEADER_DARWIN_SET_PROCESS_NAME_H_INCLUDED
+#define HEADER_DARWIN_SET_PROCESS_NAME_H_INCLUDED
+
+#include <stdbool.h>
+
+bool darwin_set_process_title(const char * title);
+
+#endif

--- a/src/darwin_set_process_name.h
+++ b/src/darwin_set_process_name.h
@@ -1,8 +1,10 @@
 #ifndef HEADER_DARWIN_SET_PROCESS_NAME_H_INCLUDED
 #define HEADER_DARWIN_SET_PROCESS_NAME_H_INCLUDED
 
+#include "spt_config.h"
+
 #include <stdbool.h>
 
-bool darwin_set_process_title(const char * title);
+HIDDEN bool darwin_set_process_title(const char * title);
 
 #endif

--- a/src/spt_status.c
+++ b/src/spt_status.c
@@ -58,6 +58,7 @@
 #endif
 #if defined(__darwin__)
 #include <crt_externs.h>
+#include "darwin_set_process_name.h"
 #endif
 
 #include "spt_status.h"
@@ -110,8 +111,11 @@ bool        update_process_title = true;
 #define PS_USE_PS_STRINGS
 #elif (defined(BSD) || defined(__bsdi__) || defined(__hurd__)) && !defined(__darwin__)
 #define PS_USE_CHANGE_ARGV
-#elif defined(__linux__) || defined(_AIX) || defined(__sgi) || (defined(sun) && !defined(BSD)) || defined(ultrix) || defined(__ksr__) || defined(__osf__) || defined(__svr4__) || defined(__svr5__) || defined(__darwin__)
+#elif defined(__linux__) || defined(_AIX) || defined(__sgi) || (defined(sun) && !defined(BSD)) || defined(ultrix) || defined(__ksr__) || defined(__osf__) || defined(__svr4__) || defined(__svr5__) 
 #define PS_USE_CLOBBER_ARGV
+#elif defined(__darwin__)
+#define PS_USE_CLOBBER_ARGV
+#define PS_USE_DARWIN
 #elif defined(WIN32)
 #define PS_USE_WIN32
 #else
@@ -344,6 +348,10 @@ set_ps_display(const char *activity, bool force)
             ps_buffer_size - ps_buffer_fixed_size);
 
     /* Transmit new setting to kernel, if necessary */
+
+#ifdef PS_USE_DARWIN
+    darwin_set_process_title(ps_buffer);
+#endif
 
 #ifdef PS_USE_SETPROCTITLE
     setproctitle("%s", ps_buffer);

--- a/tests/setproctitle_test.py
+++ b/tests/setproctitle_test.py
@@ -112,6 +112,24 @@ print(os.popen("ps -x -o pid,command 2> /dev/null").read())
     assert title == "Hello, world!"
 
 
+@pytest.mark.skipif(
+    'sys.platform != "darwin"',
+    reason="Mac only test")
+def test_setproctitle_darwin():
+    """Mac Activity monitor shows correct info"""
+    rv = run_script(
+        r"""
+import setproctitle
+setproctitle.setproctitle('QwErTyZxCvB')
+
+import os
+print(os.popen("lsappinfo find name=QwErTyZxCvB 2> /dev/null").read())
+"""
+    )
+    m = re.search(r'''ASN:.*"QwErTyZxCvB"''', rv)
+    assert m
+
+
 def test_prctl():
     """Check that prctl is called on supported platforms."""
     linux_version = []


### PR DESCRIPTION
Idea is borrowed from libuv (used by node.js)
See https://github.com/libuv/libuv/blob/v1.x/src/unix/darwin-proctitle.c
Implementation rewritten from scratch, fixing various libuv bugs among other things