### PR TITLE
Fixed #82, #103: Removed usage of Py_GetArgcArgv on MacOS

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,3 +70,19 @@ jobs:
 
       - name: Run tests
         run: tox -e ${{matrix.python-version}} -- -vrsx --color=yes
+
+  macos-native-python-test:
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout repos
+        uses: actions/checkout@v2
+
+      - name: Run tests
+        run: |
+          xcrun python3 -c "import sys; print(sys.version); print(sys.executable)"
+          xcrun python3 -m venv xcode-venv
+          . xcode-venv/bin/activate
+          pip install pytest
+          pip install .
+          pytest -vrsx --color=yes

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,3 +86,6 @@ jobs:
           pip install pytest
           pip install .
           pytest -vrsx --color=yes
+        env: 
+          CIBW_TEST_COMMAND: something
+          #hack!: prevent test_init_getproctitle relying on exact sys.executable from running

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,14 +78,11 @@ jobs:
       - name: Checkout repos
         uses: actions/checkout@v2
 
+      - name: Install Tox
+        run: xcrun python3 -m pip install tox
+
       - name: Run tests
         run: |
-          xcrun python3 -c "import sys; print(sys.version); print(sys.executable)"
-          xcrun python3 -m venv xcode-venv
-          . xcode-venv/bin/activate
-          pip install pytest
-          pip install .
-          pytest -vrsx --color=yes
-        env: 
-          CIBW_TEST_COMMAND: something
-          #hack!: prevent test_init_getproctitle relying on exact sys.executable from running
+          export XCODE_PYTHON=`xcrun python3 -c "import sys;print(sys.executable)"`
+          $XCODE_PYTHON -c "import sys; print(sys.version)"
+          $XCODE_PYTHON -m tox -e xcode -- -vrsx --color=yes

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,12 @@
 Releases history
 ----------------
 
+Version 1.3.0
+-------------
+
+- Fixed "Symbol not found: _Py_GetArgcArgv" error when using Xcode provided Python (issues #82, #103).
+
+
 Version 1.2.3
 -------------
 

--- a/src/spt_python.h
+++ b/src/spt_python.h
@@ -19,7 +19,9 @@
 #define IS_PYPY
 #endif
 
+#ifndef __darwin__
 /* defined in Modules/main.c but not publically declared */
 void Py_GetArgcArgv(int *argc, wchar_t ***argv);
+#endif
 
 #endif   /* SPT_PYTHON_H */

--- a/tox.ini
+++ b/tox.ini
@@ -21,3 +21,6 @@ basepython = python3.9
 
 [testenv:3.10]
 basepython = python3.10
+
+[testenv:xcode]
+basepython = {env:XCODE_PYTHON}


### PR DESCRIPTION
Apple supplied (e.g. via Xcode) Python does not expose `Py_GetArgcArgv` function. For our purposes calling this function is completely unnecessary since on MacOS we have documented `_NSGetArgc` and `_NSGetArgv` that return process arguments directly.
This fix removes usage of `Py_GetArgcArgv` and replaces it with `_NSGetArgc` and `_NSGetArgv`