### PR TITLE
Using prctl(PR_SET_MM, PR_SET_MM_MAP,...) on Linux instead of argv clobbering

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ platform_sources = []
 
 if sys.platform.startswith("linux"):
     define_macros["HAVE_SYS_PRCTL_H"] = 1
+    platform_sources.append("src/linux_set_process_name.c")
 
 elif sys.platform == "darwin":
     # __darwin__ symbol is not defined; __APPLE__ is instead.

--- a/src/linux_set_process_name.c
+++ b/src/linux_set_process_name.c
@@ -1,0 +1,211 @@
+#include "linux_set_process_name.h"
+
+#include <stdio.h>
+#include <stdint.h>
+#include <errno.h>
+#include <string.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <stdlib.h>
+
+
+#include <sys/prctl.h>
+#include <sys/syscall.h>
+
+#define DONE_IF(cond) if (cond) goto done;
+
+static inline char * append_format(char * buf, char * buf_end, int field_size) {
+    const char * fmt = NULL;
+    if (field_size == sizeof(unsigned long long)) {
+        fmt = "%llu";
+    } else if (field_size == sizeof(unsigned long)) {
+        fmt = "%lu";
+    } else if (field_size == sizeof(unsigned int)) {
+        fmt = "%u";
+    } else if (field_size == sizeof(unsigned short)) {
+        fmt = "%hu";
+    } else if (field_size == 0) {
+        fmt ="%*u";
+    } else {
+        return NULL;
+    }
+    size_t len = strlen(fmt);
+    if (buf + len >= buf_end)
+        return NULL;
+    memcpy(buf, fmt, len);
+    return buf + len;
+}
+
+static inline char * skip_fields(char * buf, int count) {
+    char * buf_ptr = strchr(buf, ' ');
+    for (int i = 0; i < count - 1; ++i) {
+        if (!buf_ptr)
+            return NULL;
+        buf_ptr = strchr(buf_ptr + 1, ' ');
+    }
+    return buf_ptr + 1;
+}
+
+static char * read_all(int fd, size_t * size) {
+    size_t line_size = 32;
+    char * line = malloc(line_size);
+    if (!line)
+        return NULL;
+    size_t offset = 0;
+    for ( ; ; ) {
+		ssize_t bytes_read = read(fd, line + offset, line_size - offset - 1);
+        if (bytes_read == 0) {
+            line[offset] = '\0';
+            if (size)
+                *size = offset;
+            return line;
+        }
+        if (bytes_read < 0) {
+            if (errno == EINTR)
+                continue;
+            break;
+        }
+        offset += bytes_read;
+        if (offset + 1 == line_size) {
+            if (SIZE_MAX / 2 > line_size)
+                line_size *= 2;
+            else if (SIZE_MAX - line_size > 4096)
+                line_size += 4096;
+            else 
+                break;
+            char * tmp_line = realloc(line, line_size);
+            if (!tmp_line)
+                break;
+            line = tmp_line;
+        }
+	}
+    free(line);
+    return NULL;
+}
+
+static char * proctitle = NULL;
+
+const char * linux_get_process_title() {
+
+    enum {
+        has_nothing,
+        has_fd
+    } state = has_nothing;
+
+    if (proctitle)
+        return proctitle;
+
+    int fd = open("/proc/self/cmdline", O_RDONLY | O_CLOEXEC);
+    DONE_IF(fd < 0);
+    size_t size = 0;
+    proctitle = read_all(fd, &size);
+    DONE_IF(!proctitle);
+    for(size_t i = 0; i < size - 1; ++i) {
+        if (proctitle[i] == '\0')
+            proctitle[i] = ' ';
+    }
+done:
+    switch(state) {
+        case has_fd: close(fd);
+        case has_nothing: ;
+    } 
+    return proctitle;
+}
+
+
+bool linux_set_process_title(const char * title)
+{
+    typedef struct prctl_mm_map prctl_mm_map_t;
+    
+    enum {
+        has_nothing,
+        has_fd,
+        has_buf
+    } state = has_nothing;
+    bool ret = false;
+
+    /* sanity check that our struct matches kernel's */
+    unsigned int struct_size;
+    DONE_IF(prctl(PR_SET_MM, (unsigned long)(PR_SET_MM_MAP_SIZE), &struct_size,
+                  (unsigned long)0, (unsigned long)0) != 0);
+    DONE_IF(struct_size != sizeof(prctl_mm_map_t));
+
+    
+    int fd = open("/proc/self/stat", O_RDONLY | O_CLOEXEC);
+    DONE_IF(fd < 0);
+    ++state;
+
+    char * buf = read_all(fd, NULL);
+    DONE_IF(!buf);
+    ++state;
+
+    prctl_mm_map_t prctl_map;
+
+    /* The column layout is:
+       25 columns to ignore
+       start_code
+       end_code
+       start_stack 
+       19 columns to ignore
+       start_data
+       end_data
+       start_brk
+       2 columns to ignore
+       env_start
+       env_end
+    */
+    char * buf_ptr = skip_fields(buf, 25);
+    DONE_IF(!buf_ptr);
+
+    char format_buf[64]; /* 64 ought to be enough for the longest format */
+    char * format = format_buf, * format_end = format_buf + sizeof(format_buf) - 1;
+    DONE_IF(!(format = append_format(format, format_end, sizeof(prctl_map.start_code))));
+    DONE_IF(!(format = append_format(format, format_end, sizeof(prctl_map.end_code))));
+    DONE_IF(!(format = append_format(format, format_end, sizeof(prctl_map.start_stack))));
+    *format = '\0';
+    DONE_IF(sscanf(buf_ptr, format_buf, &prctl_map.start_code, &prctl_map.end_code, &prctl_map.start_stack) != 3);
+
+    buf_ptr = skip_fields(buf_ptr, 19);
+    DONE_IF(!buf_ptr);
+
+    format = format_buf;
+    DONE_IF(!(format = append_format(format, format_end, sizeof(prctl_map.start_data))));
+    DONE_IF(!(format = append_format(format, format_end, sizeof(prctl_map.end_data))));
+    DONE_IF(!(format = append_format(format, format_end, sizeof(prctl_map.start_brk))));
+    DONE_IF(!(format = append_format(format, format_end, 0)));
+    DONE_IF(!(format = append_format(format, format_end, 0)));
+    DONE_IF(!(format = append_format(format, format_end, sizeof(prctl_map.env_start))));
+    DONE_IF(!(format = append_format(format, format_end, sizeof(prctl_map.env_end))));
+    *format = '\0';
+    DONE_IF(sscanf(buf_ptr, format_buf, &prctl_map.start_data, &prctl_map.end_data, 
+                   &prctl_map.start_brk, &prctl_map.env_start, &prctl_map.env_end) != 5);
+
+    size_t full_title_len = strlen(title) + 1;
+
+    char * tmp_proctitle = realloc(proctitle, full_title_len);
+    DONE_IF(!tmp_proctitle);
+    proctitle = tmp_proctitle;
+
+    prctl_map.arg_start = (typeof(prctl_map.arg_start))proctitle;
+    prctl_map.arg_end = prctl_map.arg_start + full_title_len;
+
+    prctl_map.brk = syscall(__NR_brk, 0);
+
+    prctl_map.auxv = NULL;
+    prctl_map.auxv_size = 0;
+    prctl_map.exe_fd = -1;
+
+    DONE_IF(prctl(PR_SET_MM, (unsigned long)(PR_SET_MM_MAP), &prctl_map,
+                  sizeof(prctl_map), (unsigned long)0) != 0);
+    memcpy(proctitle, title, full_title_len);
+    (void)prctl(PR_SET_NAME, title);
+
+    ret = true;
+done:
+    switch(state) {
+        case has_buf: free(buf);
+        case has_fd: close(fd);
+        case has_nothing: ;
+    }   
+    return ret;
+}

--- a/src/linux_set_process_name.h
+++ b/src/linux_set_process_name.h
@@ -1,0 +1,11 @@
+#ifndef HEADER_LINUX_SET_PROCESS_NAME_H_INCLUDED
+#define HEADER_LINUX_SET_PROCESS_NAME_H_INCLUDED
+
+#include "spt_config.h"
+
+#include <stdbool.h>
+
+HIDDEN bool linux_set_process_title(const char * title);
+HIDDEN const char * linux_get_process_title();
+
+#endif

--- a/src/spt_python.h
+++ b/src/spt_python.h
@@ -19,7 +19,7 @@
 #define IS_PYPY
 #endif
 
-#ifndef __darwin__
+#if !defined(__darwin__) && !defined(__linux__)
 /* defined in Modules/main.c but not publically declared */
 void Py_GetArgcArgv(int *argc, wchar_t ***argv);
 #endif

--- a/tests/setproctitle_test.py
+++ b/tests/setproctitle_test.py
@@ -422,9 +422,10 @@ print('SPT_TESTENV=testenv' in open('/proc/self/environ').read())
     assert "XXX" in _clean_up_title(title), "title not set as expected"
     title_len = int(lines[3])
     assert lines[4] == "True", "env has been clobbered"
-    assert (
-        title_len <= cmdline_len
-    ), "title (len {title_len}) not limited to argv (len {cmdline_len})"
+    if not sys.platform.startswith("linux"): #on linux there is no length limitation
+        assert (
+            title_len <= cmdline_len
+        ), "title (len {title_len}) not limited to argv (len {cmdline_len})"
 
 
 @skip_if_no_proc_env


### PR DESCRIPTION
This solves numerous issues such as dependence on non-modified environ, existence of Py_GetArgcArgv (and getting argv at all), bug #51, etc.

The downside is that it is hard to tell whether it will work on all reasonable Linux installations. The docs for `PR_SET_MM` say that it requires `CAP_SYS_RESOURCE` capability. My experiments with Ubuntu 20.04 seem to indicate that it isn't so - it works just fine with capability removed. Perhaps it is different on SELinux but I don't have one handy to check.  (OTOH inability to change title without extra steps on SELinux might be an upside...). In addition this also bumps minimum kernel requirement to 3.18 I believe. 

It is likely possible to check whether PR_SET_MM works at runtime and fall back on argc/argv but that's a whole ton of additional coding work.

In short, I am not 100% sure about this one so take it or leave it as you see fit 😀