### PR TITLE
Restore early initialization on macOS

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,13 @@
 Releases history
 ----------------
 
+Version 1.3.2
+-------------
+
+- Restore import-time initialization of macOS to avoid crash on thread+fork
+  (issue #113).
+
+
 Version 1.3.1
 -------------
 

--- a/pkg/setproctitle/__init__.py
+++ b/pkg/setproctitle/__init__.py
@@ -53,4 +53,5 @@ else:
 
 # Call getproctitle to initialize structures and avoid problems caused
 # by fork() on macOS (see #113).
-getproctitle()
+if sys.platform == "darwin":
+    getproctitle()

--- a/pkg/setproctitle/__init__.py
+++ b/pkg/setproctitle/__init__.py
@@ -49,3 +49,8 @@ else:
     getproctitle = _setproctitle.getproctitle  # noqa: F811
     setthreadtitle = _setproctitle.setthreadtitle  # noqa: F811
     getthreadtitle = _setproctitle.getthreadtitle  # noqa: F811
+
+
+# Call getproctitle to initialize structures and avoid problems caused
+# by fork() on macOS (see #113).
+getproctitle()

--- a/tests/setproctitle_test.py
+++ b/tests/setproctitle_test.py
@@ -492,6 +492,32 @@ assert p.exitcode == 0, f"p.exitcode is {p.exitcode}"
     )
 
 
+def test_thread_fork_segfault():
+    run_script(
+        """\
+import multiprocessing as mp
+from threading import Thread
+from setproctitle import setproctitle
+
+def foo():
+    setproctitle("title in child")
+
+def thread():
+    global p
+    p = mp.Process(target=foo)
+    p.start()
+    p.join()
+
+p = None
+mp.set_start_method("fork")
+t = Thread(target=thread)
+t.start()
+t.join()
+assert p.exitcode == 0, f"p.exitcode is {p.exitcode}"
+"""
+    )
+
+
 # Support functions
 
 


### PR DESCRIPTION
Perform early initialization on macOS only in order to avoid crashes on forking from a thread (#113).

Early initialization causes side effects on Linux (such as #45, #46) so we only run it on macOS.

Close #113 