### PR TITLE
add [testenv:pypy-3.8] for tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ basepython = python3.9
 basepython = python3.10
 
 [testenv:pypy-3.8]
-basepython = pypy38
+basepython = pypy3.8
 
 [testenv:xcode]
 basepython = {env:XCODE_PYTHON}

--- a/tox.ini
+++ b/tox.ini
@@ -19,5 +19,8 @@ basepython = python3.9
 [testenv:3.10]
 basepython = python3.10
 
+[testenv:pypy-3.8]
+basepython = pypy38
+
 [testenv:xcode]
 basepython = {env:XCODE_PYTHON}


### PR DESCRIPTION
tox 4 is triggering `ValueError: conflicting factors pypy, 3.8 in pypy-3.8`.  https://github.com/dvarrazzo/py-setproctitle/actions/runs/3716382749/jobs/6302641135#step:5:39  This may relate to https://github.com/tox-dev/tox/issues/2657, or maybe not, but adding the environment seemed to match the pattern for the rest.