### PR TITLE
Modernizing handling of bool type.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,7 @@ Version 1.3.5 (unreleased)
 --------------------------
 
 - Fix bouncing Dock icon on macOS (issue #143).
+- Fix building on C23 compilers (issue #145).
 
 
 Version 1.3.4

--- a/src/c.h
+++ b/src/c.h
@@ -12,20 +12,9 @@
 
 #include "spt_config.h"
 
-#ifndef __cplusplus
-
-#ifndef bool
-typedef char bool;
+#if !defined(__cplusplus) && (!defined(__STDC_VERSION__) || __STDC_VERSION__ <= 201710L)
+#include <stdbool.h>
 #endif
-
-#ifndef true
-#define true	((bool) 1)
-#endif
-
-#ifndef false
-#define false	((bool) 0)
-#endif
-#endif   /* not C++ */
 
 #include <stddef.h>
 


### PR DESCRIPTION
For C17 and below include `<stdbool.h>`. For C23 and above - do nothing. Theoretically this could fail on pre-C23 compiler with no `<stdbool.h>` header. I don't think there can be any such system in existence that also has Python versions we support.

Fixes #145 

