### PR TITLE
feat: Build armv7l wheels

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -16,7 +16,7 @@ jobs:
         run: python setup.py sdist
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: sdist
           path: ./dist/*
@@ -52,7 +52,7 @@ jobs:
             *-macosx_universal2:arm64
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: wheel-${{ matrix.pyver }}-${{ matrix.os }}
           path: ./wheelhouse/*.whl
@@ -81,7 +81,7 @@ jobs:
           CIBW_TEST_COMMAND: pytest --color=yes -m 'not embedded and not skip_on_qemu' {project}/tests
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: wheel-${{ matrix.pyver }}-${{ matrix.arch }}
           path: ./wheelhouse/*.whl
@@ -113,7 +113,7 @@ jobs:
             pp*-macosx_*
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: wheels-pp-${{ matrix.os }}
           path: ./wheelhouse/*.whl
@@ -137,7 +137,7 @@ jobs:
       # Tests mostly fail because of some confusion with the python interpreter
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: wheels-pp-cross
           path: ./wheelhouse/*.whl
@@ -153,7 +153,7 @@ jobs:
       - build-cross-wheel-pypy
     steps:
       - name: Merge Artifacts
-        uses: actions/upload-artifact/merge@v4
+        uses: actions/upload-artifact/merge@v6
         with:
           name: setproctitle-artifacts
           delete-merged: true

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v3.2.1
+        uses: pypa/cibuildwheel@v3.3.1
         env:
           CIBW_BUILD: ${{matrix.pyver}}-*
           CIBW_ARCHS_LINUX: auto
@@ -64,7 +64,7 @@ jobs:
       fail-fast: false
       matrix:
         pyver: [cp310, cp311, cp312, cp313, cp313t, cp314, cp314t]
-        arch: [aarch64, ppc64le, riscv64]
+        arch: [aarch64, armv7l, ppc64le, riscv64]
 
     steps:
       - name: Checkout repos
@@ -74,7 +74,7 @@ jobs:
         uses: docker/setup-qemu-action@v3
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v3.2.1
+        uses: pypa/cibuildwheel@v3.3.1
         env:
           CIBW_BUILD: ${{matrix.pyver}}-*
           CIBW_ARCHS: ${{matrix.arch}}
@@ -99,7 +99,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v3.2.1
+        uses: pypa/cibuildwheel@v3.3.1
         env:
           CIBW_BUILD: pp*
           CIBW_TEST_COMMAND: pytest --color=yes -m 'not embedded' {project}/tests
@@ -130,7 +130,7 @@ jobs:
         uses: docker/setup-qemu-action@v3
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v3.2.1
+        uses: pypa/cibuildwheel@v3.3.1
         env:
           CIBW_BUILD: pp*
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,3 @@ enable = [
     "pypy",
 ]
 test-extras = ["test"]
-
-[[tool.cibuildwheel.overrides]]
-select = "*riscv64*"
-before-all = ["dnf install -y --setopt=install_weak_deps=False procps-ng"]


### PR DESCRIPTION
This PR adds so manylinux wheels are built for armv7l

This is now supported since cibuildwheel 3.3.0: https://github.com/pypa/cibuildwheel/releases/tag/v3.3.0
