### PR TITLE
Add Windows ARM64 support in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,7 +49,7 @@ jobs:
 
 
   windows-tests:
-    runs-on: windows-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
@@ -62,7 +62,17 @@ jobs:
           - "3.14"
           - "3.14t"
           - "3.15.0-alpha.1"
-        architecture: ['x64', 'x86']
+        os: [windows-latest, windows-11-arm]
+        architecture: ['x64', 'x86', 'arm64']
+        exclude:
+          - os: windows-latest
+            architecture: arm64
+          - os: windows-11-arm
+            architecture: x86
+          - os: windows-11-arm
+            architecture: x64
+          - os: windows-11-arm
+            python-version: "3.10"
 
     steps:
       - name: Checkout repos


### PR DESCRIPTION
This PR adds Windows ARM64 support to the CI test matrix.

- Extends the `windows-tests` job to run on `windows-11-arm` with arm64 architecture.
- Python on Windows ARM64 is supported from 3.11+, so 3.10 is excluded for that runner.
- x86/x64 are excluded for the ARM runner, and arm64 is excluded for` windows-latest`.